### PR TITLE
Change from requests to requests_cache

### DIFF
--- a/yaschedule/core.py
+++ b/yaschedule/core.py
@@ -1,5 +1,5 @@
-import requests
 import datetime
+from requests_cache import CachedSession
 
 
 class YaSchedule:
@@ -13,6 +13,11 @@ class YaSchedule:
         """
         self.__token = token
         self.__lang = lang
+        self.session = CachedSession(
+            cache_name = __name__ + '.cache',
+            allowable_codes = [200, 404],
+            ignored_parameters = ['apikey'],
+        )
 
     def __get_payload(self, **kwargs) -> dict:
         """
@@ -30,7 +35,8 @@ class YaSchedule:
 
     def __get_response(self, api_method_url: str, payload: dict) -> dict:
         request_url = f'{self.base_url}{api_method_url}/'
-        response = requests.get(request_url, payload)
+        response = self.session.get(request_url, payload)
+        # TODO: add HTTP '429 Too Many Requests' handler and other non-200 codes (and corresponding :raises doc)
         return response.json()
 
     def get_all_stations(self, **kwargs) -> dict:


### PR DESCRIPTION
I think it's good idea to implement caching (especially for such methods as [/stations_list](https://yandex.ru/dev/rasp/doc/ru/reference/stations-list))

In this MR you can set and change caching params using `yaschedule.session` property - it support same params as [requests_cache.session.CachedSession](https://requests-cache.readthedocs.io/en/stable/modules/requests_cache.session.html#requests_cache.session.CachedSession). Good defaults for `allowable_codes` and `ignored_parameters` I've already set.

E.g.

```python
from yaschedule.core import YaSchedule
yaschedule = YaSchedule(TOKEN)

print(yaschedule.session.settings.expire_after) # get particular cache setting
yaschedule.session.settings.expire_after = 600 # set particular cache setting

print(yaschedule.session.settings) # get all cache settings as object of <class 'requests_cache.policy.settings.CacheSettings'>
print({ a : getattr(yaschedule.session.settings, a) for a in dir(yaschedule.session.settings) if not a.startswith('_') }) # get all cache settings as dict
```

See more at [requests_cache](https://requests-cache.readthedocs.io/) docs